### PR TITLE
App homen nappien tapahtumakäsittelijät toimimaan käyttöliittymän tilan perusteella

### DIFF
--- a/database.js
+++ b/database.js
@@ -9,7 +9,8 @@ const sequelize = new Sequelize(process.env.DB_SCHEMA || 'postgres',
                                     dialect: 'postgres',
                                     dialectOptions: {
                                         ssl: process.env.DB_SSL == "true"
-                                    }
+                                    },
+                                    logging: false
                                 });
 
 const db = {};

--- a/databaseService.js
+++ b/databaseService.js
@@ -15,8 +15,8 @@ const getEnrollmentsFor = async (date) => {
  * @param {string} userId - Slack user id.
  * @param {string} date - Date string in the ISO date format.
  */
-const toggleSignup = async (userId, date, atOffice = true) => {
-  if (await userInOffice(userId, date, atOffice)) {
+const toggleSignup = async (userId, date, signIn, atOffice = true) => {
+  if (!signIn) {
     await db.removeSignup(userId, date)
   } else {
     await db.addSignupForUser(userId, date, atOffice)

--- a/home.js
+++ b/home.js
@@ -38,12 +38,18 @@ const update = async (client, userId) => {
       usersString += `<@${user}>\n`
     })
 
+    const buttonValue = {
+      date: d,
+      inOffice: await service.userInOffice(userId, d),
+      isRemote: await service.userIsRemote(userId, d)
+    }
+
     blocks = blocks.concat(
       mrkdwn(usersString),
       plain_text("Oma ilmoittautumiseni:"),
       actions([
-        button('Toimistolla', 'toimistolla_click', d, `${await service.userInOffice(userId, d) ? 'primary' : null}`),
-        button('Etänä', 'etana_click', d, `${await service.userIsRemote(userId, d) ? 'primary' : null}`)
+        button('Toimistolla', 'toimistolla_click', JSON.stringify(buttonValue), `${buttonValue.inOffice ? 'primary' : null}`),
+        button('Etänä', 'etana_click', JSON.stringify(buttonValue), `${buttonValue.isRemote ? 'primary' : null}`)
       ]),
       divider()
     )

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ app.event('app_home_opened', async ({ event, client }) => {
  * Marks the user present in the office for the selected day and updates the App-Home page.
  */
 app.action(`toimistolla_click`, async ({ body, ack, client }) => {
-  await service.toggleSignup(body.user.id, body.actions[0].value)
+  const data = JSON.parse(body.actions[0].value)
+  await service.toggleSignup(body.user.id, data.date, !data.inOffice)
   home.update(client, body.user.id);
   await ack();
 });
@@ -49,7 +50,8 @@ app.action(`toimistolla_click`, async ({ body, ack, client }) => {
  * Marks the user not present in the office for the selected day and updates the App-Home page.
  */
 app.action(`etana_click`, async ({ body, ack, client}) => {
-  await service.toggleSignup(body.user.id, body.actions[0].value, false)
+  const data = JSON.parse(body.actions[0].value)
+  await service.toggleSignup(body.user.id, data.date, !data.isRemote, false)
   home.update(client, body.user.id);
   await ack();
 });


### PR DESCRIPTION
closes #25

Togglaaminen tapahtuu nyt käyttöliittymän tilan perusteella eikä tietokannan. Näin tehdään aina se toiminto, jonka käyttäjä halusi tehdä, riippumatta siitä onko viimeisin tieto päivittynyt käyttöliittymään.

Ohessa kytketty sequelizen loggaus pois päältä.