### PR TITLE
Slash-command rajapinta

### DIFF
--- a/databaseService.js
+++ b/databaseService.js
@@ -10,7 +10,7 @@ const { DateTime } = require("luxon");
 const getEnrollmentsFor = async (date) => {
   const slackIds = await db.getAllOfficeSignupsForADate(date)
   const homeIds = await db.getAllOfficeSignupsForADate(date, false)
-  const defaultIds = await db.getAllOfficeDefaultSignupsForAWeekday(dfunc.weekdays[DateTime.fromISO(date).weekday-1])
+  const defaultIds = await db.getAllOfficeDefaultSignupsForAWeekday(dfunc.weekdays[DateTime.fromISO(date).weekday - 1])
   let set = new Set(slackIds)
   let etana = new Set(homeIds)
   defaultIds.forEach((id) => {

--- a/dateFunctions.js
+++ b/dateFunctions.js
@@ -6,18 +6,23 @@ const weekdays = [
     'Tiistai',
     'Keskiviikko',
     'Torstai',
-    'Perjantai'
+    'Perjantai',
+    'Lauantai',
+    'Sunnuntai'
   ]
 const shortWeekdays = [
     'Ma',
     'Ti',
     'Ke',
     'To',
-    'Pe'
+    'Pe',
+    'La',
+    'Su'
   ]
 const MAX_INPUT_LENGTH = 20
 const RECORD_LIMIT = 180
 const MAX_DIFFERENCE = 2
+const WEEKDAYS_COUNT = 5
 
 /**
  * Returns a list of strings representing one week, starting from next monday calculated from the given day.
@@ -98,17 +103,19 @@ const isWeekday = (date) => {
  * @param {string} str - String to be matched.
  */
 const matchWeekday = str => {
-    if (str.length > MAX_INPUT_LENGTH) return 0
+    if (str.length > MAX_INPUT_LENGTH) return 0 //Ei haluta tehdä alla olevaa liian pitkille syötteille
+    //Katsotaan vastaako merkkijono jotain lyhennettä
     for (let i = 0; i < shortWeekdays.length; i++) {
         if (str.toLowerCase() === shortWeekdays[i].toLowerCase()) return i + 1
     }
+    //Katsotaan, onko merkkijono tarpeeksi lähellä mitää viikonpäivää ja jos on, palautetaan sen päivän numero
     dist = new Array(weekdays.length)
     for (let i = 0; i < weekdays.length; i++) {
         dist[i] = [editDistance(str.toLowerCase(), weekdays[i].toLowerCase()) , i]
     }
-    dist.sort((a,b) => a[0]-b[0])
+    dist.sort((a,b) => a[0] - b[0])
     if (dist[0][0] <= MAX_DIFFERENCE) return dist[0][1] + 1
-    return 0
+    return 0 //Muuten palautetaan nolla
 }
 
 /** 
@@ -139,7 +146,6 @@ const editDistance = (str1, str2) => {
 const toPrettyFormat = (datestring) => {
     const parts = datestring.split('-')
     const newDate = DateTime.fromObject({ year: parts[0], month: parts[1], day: parts[2] })
-    if (newDate.weekday - 1 >= weekdays.length) return ""
     const res = `${weekdays[newDate.weekday - 1]} ${newDate.day}.${newDate.month}.`
     return res
 }

--- a/dateFunctions.js
+++ b/dateFunctions.js
@@ -62,7 +62,7 @@ const parseDate = (input, today) => {
     if (isToday(input)) return today
     if (isTomorrow(input)) return today.plus({ days: 1 })
     weekday = matchWeekday(input)
-    if (weekday != 0) {
+    if (weekday) {
         return today.plus({ days: (weekday + 7 - today.weekday)%7 })
     }
     const regex = /^([0-9]+\.[0-9]+(\.)?)$/

--- a/dateFunctions.js
+++ b/dateFunctions.js
@@ -80,8 +80,8 @@ const parseDate = (input, today) => {
 
 const isToday = (input) => {
   if (input.length > MAX_INPUT_LENGTH) return false
-    if (editDistance(input.toLowerCase(), "tänään") <= MAX_DIFFERENCE) return true
-      return false
+  if (editDistance(input.toLowerCase(), "tänään") <= MAX_DIFFERENCE) return true
+  return false
 }
 
 const isTomorrow = (input) => {

--- a/index.js
+++ b/index.js
@@ -76,14 +76,15 @@ app.action('default_etana', async ({ body, ack, client }) => {
 });
 
 /**
- * Listens to a slash-command in private messages and prints a list of people at the office on the given day.
+ * Listens to a slash-command and prints a list of people at the office on the given day.
  */
-app.command("/listaa", async ({ command, ack, say }) => {
+app.command("/listaa", async ({ command, ack, client }) => {
     try {
         await ack();
+        const channelId = command.channel_id
+        const userId = command.user_id
         let parameter = command.text //Antaa käskyn parametrin, eli kaiken mitä tulee slash-komennon ja ensimmäisen välilyönnin jälkeen
         const date = dfunc.parseDate(parameter, DateTime.now())
-        console.log(date.toString())
         if (date.isValid) {
             const enrollments = await service.getEnrollmentsFor(date.toISODate())
             let response = dfunc.weekdays[date.weekday - 1] + "na " + date.day + "." + date.month + ". toimistolla "
@@ -93,14 +94,22 @@ app.command("/listaa", async ({ command, ack, say }) => {
             enrollments.forEach((user) => {
                 response += `<@${user}>\n`
             })
-            await say(response)
+            await client.chat.postEphemeral({
+                channel: channelId,
+                user: userId,
+                text: response
+            });
         } else {
-            await say("Anteeksi, en ymmärtänyt äskeistä.")
+            await client.chat.postEphemeral({
+                channel: channelId,
+                user: userId,
+                text: "Anteeksi, en ymmärtänyt äskeistä."
+            });
         }
     } catch (error) {
         console.log("Tapahtui virhe :(")
         console.log(error)
-    } 
+    }
 });
 
 /**

--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ async function guestHandler({ payload, body, client, next, ack, event }) {
   } catch (error) {
     // This user is restricted. Show them an error message and don't continue processing the request
     if (error === 'User is restricted') {
-      if (event.channel_type !== undefined && event.channel_type === 'channel') { // Don't send the error message, if message comes from a normal channel
+      if (event !== undefined && event.channel_type === 'channel') { // Don't send the error message, if message comes from a normal channel
         return
       }
       const message = `Pahoittelut, <@${userId}>. Olet vieraskäyttäjä tässä Slack-työtilassa, joten et voi käyttää tätä bottia.`

--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ app.command("/listaa", async ({ command, ack, client }) => {
     const date = dfunc.parseDate(parameter, DateTime.now())
     if (date.isValid) {
       const registrations = await service.getRegistrationsFor(date.toISODate())
-      let response = atWeekday(date) + " toimistolla "
-      if (registrations.length === 0) response = "Kukaan ei ole toimistolla " + atWeekday(date).toLowerCase()
+      let response = dfunc.atWeekday(date) + " toimistolla "
+      if (registrations.length === 0) response = "Kukaan ei ole toimistolla " + dfunc.atWeekday(date).toLowerCase()
       else if (registrations.length === 1) response += "on:\n"
       else response += "ovat:\n"
       registrations.forEach((user) => {

--- a/index.js
+++ b/index.js
@@ -285,10 +285,10 @@ async function postMessage(channelId, text) {
  */
 async function postEphemeralMessage(channelId, userId, text) {
   await app.client.chat.postEphemeral({
-        channel: channelId,
-        user: userId,
-        text: text
-      });
+    channel: channelId,
+    user: userId,
+    text: text
+  });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -76,28 +76,31 @@ app.action('default_etana', async ({ body, ack, client }) => {
 });
 
 /**
- * Listens to a command in private messages and prints a list of people at the office on the given day.
+ * Listens to a slash-command in private messages and prints a list of people at the office on the given day.
  */
-app.event('message', async({ event, say }) => {
-    if (event.channel_type === "im" && event.text !== undefined) {
-        const date = dfunc.parseDate(event.text, DateTime.now())
+app.command("/listaa", async ({ command, ack, say }) => {
+    try {
+        await ack();
+        let parameter = command.text //Antaa käskyn parametrin, eli kaiken mitä tulee slash-komennon ja ensimmäisen välilyönnin jälkeen
+        const date = dfunc.parseDate(parameter, DateTime.now())
+        console.log(date.toString())
         if (date.isValid && dfunc.isWeekday(date)) {
             const enrollments = await service.getEnrollmentsFor(date.toISODate())
-            let response = ""
+            let response = dfunc.weekdays[date.weekday - 1] + "na " + date.day + "." + date.month + ". toimistolla "
             if (enrollments.length === 0) response = "Kukaan ei ole toimistolla " + dfunc.weekdays[date.weekday - 1].toLowerCase() + "na " + date.day + "." + date.month + "."
-            else {
-                response = dfunc.weekdays[date.weekday - 1] + "na " + date.day + "." + date.month + ". toimistolla "
-                if (enrollments.length === 1) response += "on:\n"
-                else response += "ovat:\n"
-                enrollments.forEach((user) => {
-                    response += `<@${user}>\n`
-                })
-            }
+            else if (enrollments.length === 1) response += "on:\n"
+            else response += "ovat:\n"
+            enrollments.forEach((user) => {
+                response += `<@${user}>\n`
+            })
             await say(response)
         } else {
             await say("Anteeksi, en ymmärtänyt äskeistä.")
         }
-    }
+    } catch (error) {
+        console.log("Tapahtui virhe :(")
+        console.log(error)
+    } 
 });
 
 /**

--- a/index.js
+++ b/index.js
@@ -140,10 +140,15 @@ async function getUserRestriction(userId) {
  * is a guest (restricted), and if so, stops further processing of the request, 
  * displaying an error message instead.
  */
-async function guestHandler({ payload, body, client, next }) {
+async function guestHandler({ payload, body, client, next, ack }) {
   // The user ID is found in many different places depending on the type of action taken
+  console.log(payload)
   var userId // Undefined evaluates as false
   if (!userId) try {userId = payload.user} catch (error) {} // tab
+  if (!userId) try { // slash command
+    await ack();
+    userId = payload.user_id
+  } catch (error) {}
   if (!userId) try {userId = body.user.id} catch (error) {} // button
   if (!userId) try {userId = body.event.message.user} catch (error) {} // message edit
   // Approve requests which don't include any of the above (couldn't find any)
@@ -161,7 +166,13 @@ async function guestHandler({ payload, body, client, next }) {
     // This user is restricted. Show them an error message and don't continue processing the request
     if (error === 'User is restricted') {
       const message = `Pahoittelut, <@${userId}>. Olet vieraskäyttäjä tässä Slack-työtilassa, joten et voi käyttää tätä bottia.`
-      if (payload.channel === undefined || payload.tab === 'home') {
+      if (payload.channel === undefined && payload.tab === undefined) { //Send an ephemeral message back to the channel where the slack command came from
+        await client.chat.postEphemeral({
+          channel: payload.channel_id,
+          user: userId,
+          text: message
+        });
+      } else if (payload.channel === undefined || payload.tab === 'home') {
         home.error(client, userId, message); // Home tab requests show the message on the home tab
       } else { // Otherwise send a private message
         await client.chat.postEphemeral({

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ app.command("/listaa", async ({ command, ack, say }) => {
         let parameter = command.text //Antaa käskyn parametrin, eli kaiken mitä tulee slash-komennon ja ensimmäisen välilyönnin jälkeen
         const date = dfunc.parseDate(parameter, DateTime.now())
         console.log(date.toString())
-        if (date.isValid && dfunc.isWeekday(date)) {
+        if (date.isValid) {
             const enrollments = await service.getEnrollmentsFor(date.toISODate())
             let response = dfunc.weekdays[date.weekday - 1] + "na " + date.day + "." + date.month + ". toimistolla "
             if (enrollments.length === 0) response = "Kukaan ei ole toimistolla " + dfunc.weekdays[date.weekday - 1].toLowerCase() + "na " + date.day + "." + date.month + "."

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,7 @@ oauth_config:
       - channels:read
       - reactions:read
       - usergroups:read
+      - commands
 settings:
   event_subscriptions:
     bot_events:

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,10 @@ features:
   bot_user:
     display_name: hybridilusmu
     always_online: true
+  slash_commands:
+    - command: /listaa
+      description: Listaa paikallaolijat
+      usage_hint: /listaa päivä
 oauth_config:
   scopes:
     bot:

--- a/test/dateFunctions.test.js
+++ b/test/dateFunctions.test.js
@@ -180,11 +180,11 @@ describe('Match Weekday Tests', () => {
     it('All letters small', () => {
         assert.equal(dfunc.matchWeekday("maanantai"), 1)
     });
-    it('Input string is not a weekday', () => {
-        assert.equal(dfunc.matchWeekday("kurpitsa"), 0)
+    it('Input string is weekend', () => {
+        assert.equal(dfunc.matchWeekday("Lauantai"), 6)
     });
     it('Input string is not a weekday', () => {
-        assert.equal(dfunc.matchWeekday("Lauantai"), 0)
+        assert.equal(dfunc.matchWeekday("kurpitsa"), 0)
     });
     it('Input string is an empty string', () => {
         assert.equal(dfunc.matchWeekday(""), 0)
@@ -223,10 +223,10 @@ describe('Pretty Format Tests', () => {
         assert.equal(dfunc.toPrettyFormat("2021-10-15"), "Perjantai 15.10.")
     });
     it('Saturday returns an empty string', () => {
-        assert.equal(dfunc.toPrettyFormat("2021-10-16"), "")
+        assert.equal(dfunc.toPrettyFormat("2021-10-16"), "Lauantai 16.10.")
     });
     it('Sunday returns an empty string', () => {
-        assert.equal(dfunc.toPrettyFormat("2021-10-17"), "")
+        assert.equal(dfunc.toPrettyFormat("2021-10-17"), "Sunnuntai 17.10.")
     });
 });
 

--- a/test/dateFunctions.test.js
+++ b/test/dateFunctions.test.js
@@ -222,10 +222,10 @@ describe('Pretty Format Tests', () => {
     it('Normal weekday 2', () => {
         assert.equal(dfunc.toPrettyFormat("2021-10-15"), "Perjantai 15.10.")
     });
-    it('Saturday returns an empty string', () => {
+    it('Weekend 1, Saturday', () => {
         assert.equal(dfunc.toPrettyFormat("2021-10-16"), "Lauantai 16.10.")
     });
-    it('Sunday returns an empty string', () => {
+    it('Weekend 2, Sunday', () => {
         assert.equal(dfunc.toPrettyFormat("2021-10-17"), "Sunnuntai 17.10.")
     });
 });


### PR DESCRIPTION
Päivämääräkysely on nyt muutettu /listaa -komennoksi, joka toimii missä vain kanavalla, missä bottin on mukana. Vastaus näkyy vain kyselyn tehneelle käyttäjälle ja kysely ei näy missään muualla kuin komentoa kirjoittaessa.
/listaa komento ottaa yhden parametrin, eli päivän missä vain muodossa, missä komento päivän aikaisemminkin hyväksyi.
Samalla viikonlopun päivien vastaukset on yhtenäistetty, eli viikonlopun päiviä käsitellään nyt aivan samalla tavalla kuin mitä tahansa muutakin päivää, jolle ei ole kukaan ilmoittautunut.
Closes #38 