### PR TITLE
Make buttons work better

### DIFF
--- a/src/blocks/elements/button.js
+++ b/src/blocks/elements/button.js
@@ -1,15 +1,19 @@
-const button = (text, callback, value, style) => {
+const button = (text, callback, value, style, registrationStatus = null) => {
     const buttonElement = {
         type: 'button',
         text: {
             type: 'plain_text',
             emoji: true,
-            text,
+            text: text,
         },
         value,
         action_id: callback,
     };
-    if (style === 'primary' || style === 'danger') { buttonElement.style = style; }
+    if (style === 'primary' || style === 'danger') {
+        buttonElement.style = style;
+        if (registrationStatus === 'normal') buttonElement.text.text = `${text} :writing_hand:`;
+        if (registrationStatus === 'default') buttonElement.text.text = `${text} :robot_face:`;
+    }
     return (buttonElement);
 };
 

--- a/src/blocks/elements/button.js
+++ b/src/blocks/elements/button.js
@@ -4,7 +4,7 @@ const button = (text, callback, value, style, registrationStatus = null) => {
         text: {
             type: 'plain_text',
             emoji: true,
-            text: text,
+            text,
         },
         value,
         action_id: callback,

--- a/src/databaseService.js
+++ b/src/databaseService.js
@@ -99,7 +99,7 @@ module.exports = {
     changeDefaultRegistration,
     getRegistrationsFor,
     userAtOffice,
-    userIsRemote,
     userAtOfficeByDefault,
+    userIsRemote,
     userIsRemoteByDefault,
 };

--- a/src/home.js
+++ b/src/home.js
@@ -62,11 +62,12 @@ const getDefaultSettingsBlock = async (userId) => {
 const getUpdateBlock = async () => {
     const updateBlock = [];
     updateBlock.push(
-        plainText(`Tiedot päivitetty ${DateTime.now().setZone('Europe/Helsinki').setLocale('fi').toLocaleString(format)}`),
+        header('ILMOITTAUTUMISET :spiral_calendar_pad:'),
         actions([
-            button('Päivitä', 'update_click', 'updated'),
             button('Oletusasetukset', 'settings_click', 'updated'),
+            button('Päivitä', 'update_click', 'updated'),
         ]),
+        mrkdwn(`(_Tiedot päivitetty ${DateTime.now().setZone('Europe/Helsinki').setLocale('fi').toLocaleString(format)}_)`),
         divider(),
     );
     return updateBlock;
@@ -78,7 +79,7 @@ const getUpdateBlock = async () => {
  */
 const getRegistrationsBlock = async (userId) => {
     const registrationsBlock = [];
-    registrationsBlock.push(plainText(':writing_hand: = Käsin tehty ilmoittautuminen   :robot_face: = Oletusilmoittautuminen'));
+    registrationsBlock.push(plainText(':writing_hand: = Käsin tehty ilmoittautuminen   :robot_face: = Oletusilmoittautuminen\n'));
     const dates = dfunc.listNWeekdays(DateTime.now(), SHOW_DAYS_UNTIL);
     for (let i = 0; i < dates.length; i += 1) {
         const date = dates[i];
@@ -110,7 +111,6 @@ const getRegistrationsBlock = async (userId) => {
                 button('Toimistolla', 'office_click', JSON.stringify(buttonValue), officeColor, emoji),
                 button('Etänä', 'remote_click', JSON.stringify(buttonValue), remoteColor, emoji),
             ]),
-            divider(),
         );
     }
     return registrationsBlock;

--- a/src/home.js
+++ b/src/home.js
@@ -111,6 +111,7 @@ const getRegistrationsBlock = async (userId) => {
                 button('Toimistolla', 'office_click', JSON.stringify(buttonValue), officeColor, emoji),
                 button('Etänä', 'remote_click', JSON.stringify(buttonValue), remoteColor, emoji),
             ]),
+            divider(),
         );
     }
     return registrationsBlock;

--- a/src/home.js
+++ b/src/home.js
@@ -78,6 +78,7 @@ const getUpdateBlock = async () => {
  */
 const getRegistrationsBlock = async (userId) => {
     const registrationsBlock = [];
+    registrationsBlock.push(plainText(`:writing_hand: = Käsin tehty ilmoittautuminen   :robot_face: = Oletusilmoittautuminen`));
     const dates = dfunc.listNWeekdays(DateTime.now(), SHOW_DAYS_UNTIL);
     for (let i = 0; i < dates.length; i += 1) {
         const date = dates[i];
@@ -91,13 +92,23 @@ const getRegistrationsBlock = async (userId) => {
             date,
             atOffice: await service.userAtOffice(userId, date), // eslint-disable-line
             isRemote: await service.userIsRemote(userId, date), // eslint-disable-line
+            atOfficeDefault: await service.userAtOfficeByDefault(userId, dfunc.getWeekday(DateTime.fromISO(date))), // eslint-disable-line
+            isRemoteDefault: await service.userIsRemoteByDefault(userId, dfunc.getWeekday(DateTime.fromISO(date))), // eslint-disable-line
         };
+        let officeColor = `${buttonValue.atOfficeDefault ? 'primary' : null}`
+        let remoteColor = `${buttonValue.isRemoteDefault ? 'primary' : null}`
+        let emoji = 'default';
+        if (buttonValue.atOffice || buttonValue.isRemote) {
+            officeColor = `${buttonValue.atOffice ? 'primary' : null}`;
+            remoteColor = `${buttonValue.isRemote ? 'primary' : null}`;
+            emoji = 'normal';
+        }
         registrationsBlock.push(
             mrkdwn(userIdList),
             plainText('Oma ilmoittautumiseni:'),
             actions([
-                button('Toimistolla', 'office_click', JSON.stringify(buttonValue), `${buttonValue.atOffice ? 'primary' : null}`),
-                button('Etänä', 'remote_click', JSON.stringify(buttonValue), `${buttonValue.isRemote ? 'primary' : null}`),
+                button('Toimistolla', 'office_click', JSON.stringify(buttonValue), officeColor, emoji),
+                button('Etänä', 'remote_click', JSON.stringify(buttonValue), remoteColor, emoji),
             ]),
             divider(),
         );

--- a/src/home.js
+++ b/src/home.js
@@ -78,7 +78,7 @@ const getUpdateBlock = async () => {
  */
 const getRegistrationsBlock = async (userId) => {
     const registrationsBlock = [];
-    registrationsBlock.push(plainText(`:writing_hand: = Käsin tehty ilmoittautuminen   :robot_face: = Oletusilmoittautuminen`));
+    registrationsBlock.push(plainText(':writing_hand: = Käsin tehty ilmoittautuminen   :robot_face: = Oletusilmoittautuminen'));
     const dates = dfunc.listNWeekdays(DateTime.now(), SHOW_DAYS_UNTIL);
     for (let i = 0; i < dates.length; i += 1) {
         const date = dates[i];
@@ -95,8 +95,8 @@ const getRegistrationsBlock = async (userId) => {
             atOfficeDefault: await service.userAtOfficeByDefault(userId, dfunc.getWeekday(DateTime.fromISO(date))), // eslint-disable-line
             isRemoteDefault: await service.userIsRemoteByDefault(userId, dfunc.getWeekday(DateTime.fromISO(date))), // eslint-disable-line
         };
-        let officeColor = `${buttonValue.atOfficeDefault ? 'primary' : null}`
-        let remoteColor = `${buttonValue.isRemoteDefault ? 'primary' : null}`
+        let officeColor = `${buttonValue.atOfficeDefault ? 'primary' : null}`;
+        let remoteColor = `${buttonValue.isRemoteDefault ? 'primary' : null}`;
         let emoji = 'default';
         if (buttonValue.atOffice || buttonValue.isRemote) {
             officeColor = `${buttonValue.atOffice ? 'primary' : null}`;


### PR DESCRIPTION
Oletusilmoittautumisen lisääminen aiheuttaa nyt myös tavallisessa listauksessa ilmoittautumista vastaavan nappulan värittymisen. Samalla oletusilmoittautuminen ja tavallinen ilmoittautuminen on nyt erotettu nappuloissa näkyvillä emojeilla. Nappulat toimivat nyt niin, että oletuksena pohjalla näytetään oletusilmoittautuminen, jos sellainen on. Käyttäjä voi ilmoittautumisnappuloita klikkaamalla ylikirjoittaa oletusilmoittautumisen ja tällöin näytetään vain tavallinen ilmoittautuminen. Tavallisen ilmoittautumisen poistaminen näyttää taas pohjalla olevan oletusilmoittautumisen, jos sellainen on.
Closes #43 