### PR TITLE
Date is interpreted as the nearest possible matching date.

### DIFF
--- a/src/dateFunctions.js
+++ b/src/dateFunctions.js
@@ -19,7 +19,7 @@ const shortWeekdays = [
     'Su',
 ];
 const MAX_INPUT_LENGTH = 20;
-const RECORD_LIMIT = 180;
+const HALF_YEAR = 182;
 const MAX_DIFFERENCE = 2;
 
 /**
@@ -160,7 +160,8 @@ const parseDate = (input, today) => {
     if (!regex.test(input)) return DateTime.fromObject({ day: 0 });
     const pieces = input.split('.');
     let date = DateTime.fromObject({ month: pieces[1], day: pieces[0] });
-    if (date < today.minus({ days: RECORD_LIMIT })) date = date.plus({ years: 1 });
+    if (date < today.minus({ days: HALF_YEAR })) date = date.plus({ years: 1 });
+    if (date > today.plus({ days: HALF_YEAR })) date = date.minus({ years: 1 });
     return date;
 };
 

--- a/test/dateFunctions.test.js
+++ b/test/dateFunctions.test.js
@@ -2,8 +2,6 @@ const assert = require('assert');
 const { DateTime } = require('luxon');
 const dfunc = require('../src/dateFunctions');
 
-const RECORD_LIMIT = 180;
-
 describe('List N Weekdays Test', () => {
     it('Calculate starting from Monday, 6 days', () => {
         const wantedResult = [
@@ -74,28 +72,6 @@ describe('Parse Date Tests', () => {
         assert.equal(dfunc.parseDate('14.12.', today).toString(),
             DateTime.local(2021, 12, 14).toString());
     });
-    it('Asking far away into the future', () => {
-        const today = DateTime.local(2021, 10, 1);
-        assert.equal(dfunc.parseDate('3.12.', today).toString(),
-            DateTime.local(2021, 12, 3).toString());
-    });
-    it('Asking even further away into the future', () => {
-        const today = DateTime.local(2021, 10, 1);
-        assert.equal(dfunc.parseDate('1.2.', today).toString(),
-            DateTime.local(2022, 2, 1).toString());
-    });
-    it('Asking about the past', () => {
-        const today = DateTime.local(2021, 10, 13);
-        assert.equal(dfunc.parseDate('1.10.', today).toString(),
-            DateTime.local(2021, 10, 1).toString());
-    });
-    it('Asking beyond the RECORD_LIMIT', () => {
-        const today = DateTime.local(2021, 10, 13);
-        const pastDay = today.minus({ days: (RECORD_LIMIT + 1) });
-        const input = `${pastDay.day}.${pastDay.month}.`;
-        assert.equal(dfunc.parseDate(input, today).toString(),
-            pastDay.plus({ years: 1 }).toString());
-    });
     it('Today', () => {
         const today = DateTime.local(2021, 10, 22);
         assert.equal(dfunc.parseDate('Tänään', today).toString(),
@@ -119,6 +95,44 @@ describe('Parse Date Tests', () => {
     });
     it('Input does not match regex 2', () => {
         assert.equal(dfunc.parseDate('1.1.2020', DateTime.now()).toString(), DateTime.fromObject({ day: 0 }).toString());
+    });
+});
+
+describe('Date interpretation tests', () => {
+    it('Asking about the future 1', () => {
+        const today = DateTime.local(2021, 10, 1);
+        assert.equal(dfunc.parseDate('3.12.', today).toString(),
+            DateTime.local(2021, 12, 3).toString());
+    });
+    it('Asking about the future 2', () => {
+        const today = DateTime.local(2021, 3, 20);
+        assert.equal(dfunc.parseDate('12.7.', today).toString(),
+            DateTime.local(2021, 7, 12).toString());
+    });
+    it('Asking about the future 3 - asking about next year.', () => {
+        const today = DateTime.local(2021, 10, 1);
+        assert.equal(dfunc.parseDate('1.2.', today).toString(),
+            DateTime.local(2022, 2, 1).toString());
+    });
+    it('Asking about the future 4 - asking about next year.', () => {
+        const today = DateTime.local(2021, 12, 30);
+        assert.equal(dfunc.parseDate('1.1.', today).toString(),
+            DateTime.local(2022, 1, 1).toString());
+    });
+    it('Asking about the past 1', () => {
+        const today = DateTime.local(2021, 10, 13);
+        assert.equal(dfunc.parseDate('1.10.', today).toString(),
+            DateTime.local(2021, 10, 1).toString());
+    });
+    it('Asking about the past 2', () => {
+        const today = DateTime.local(2021, 10, 1);
+        assert.equal(dfunc.parseDate('1.6.', today).toString(),
+            DateTime.local(2021, 6, 1).toString());
+    });
+    it('Asking about the past 3 - asking about previous year.', () => {
+        const today = DateTime.local(2021, 1, 1);
+        assert.equal(dfunc.parseDate('30.12.', today).toString(),
+            DateTime.local(2020, 12, 30).toString());
     });
 });
 


### PR DESCRIPTION
Input date to slash commands is now interpreted as the nearest possible matching date. Basically, first the given date is assumed to be of the current year. But if the date is more than half a year ahead of the current date, it is interpreted as being less than half a year behind the current date, since that is closer. The same way works for dates more than half a year behind the current date, but the other way around.

Tests updated as well, to test this feature better.